### PR TITLE
[Board] 부서 게시판 필드 실시간 적용

### DIFF
--- a/src/features/boards/department/components/boardDetails/DepartmentBoardDetailsBody.js
+++ b/src/features/boards/department/components/boardDetails/DepartmentBoardDetailsBody.js
@@ -8,10 +8,12 @@ const DepartmentBoardDetailsBody = ({ board, imagePrefix }) => {
                 <span>작성자: {board.author} ({board.department}, {board.position})</span><br />
                 <span>작성일: {new Date(board.createdAt).toLocaleString()}</span>
             </div>
-            <p dangerouslySetInnerHTML={{ __html: board.content.replace(/\n/g, '<br />') }}></p>
+
+            {/* board.content가 빈 문자열 또는 null일 경우 기본값 설정 */}
+            <p dangerouslySetInnerHTML={{ __html: board.content ? board.content.replace(/\n/g, '<br />') : '내용이 없습니다.' }}></p>
 
             {/* 파일 다운로드 버튼 */}
-            {board.fileList && <DownloadButton fileList={board.fileList} imagePrefix={imagePrefix}/>}
+            {board.fileList && <DownloadButton fileList={board.fileList} imagePrefix={imagePrefix} />}
         </div>
     );
 };

--- a/src/features/boards/department/components/boardDetails/DepartmentBoardDetailsHeader.css
+++ b/src/features/boards/department/components/boardDetails/DepartmentBoardDetailsHeader.css
@@ -7,6 +7,7 @@
 /* Style for the important icon */
 .icon img.important-icon {
     position: absolute;
+    cursor: pointer;
     height: 24px;
     width: 24px;
     left: 10px;

--- a/src/features/boards/department/components/boardDetails/DepartmentBoardDetailsHeader.js
+++ b/src/features/boards/department/components/boardDetails/DepartmentBoardDetailsHeader.js
@@ -1,32 +1,58 @@
 import React from 'react';
 import './DepartmentBoardDetailsHeader.css';
 
-const DepartmentBoardDetailsHeader = ({ title, isImportant, imagePrefix, name, board, setShowEditModal, setShowDeleteModal }) => {
+const DepartmentBoardDetailsHeader = ({ title, isImportant, isLocked, imagePrefix, name, board, setShowEditModal, setShowIsLockedEditModal, setShowIsImportantEditModal, setShowDeleteModal }) => {
     return (
         <div className="card-header">
             <div className="icon">
+                {/* 중요 여부 아이콘 */}
                 <img
                     src={isImportant ? `${imagePrefix}/shared/isImportant_true.png` : `${imagePrefix}/shared/isImportant_false.png`}
                     alt={isImportant ? 'important!' : 'not important'}
                     className="important-icon"
+                    onClick={(e) => {
+                        e.stopPropagation(); // 이벤트 버블링 방지
+                        setShowIsImportantEditModal(true);
+                    }}
+                />
+
+                {/* 잠금 상태 아이콘 */}
+                <img
+                    src={isLocked ? `${imagePrefix}/shared/lock.png` : `${imagePrefix}/shared/unlock.png`}
+                    alt={isLocked ? 'lock' : 'unlock'}
+                    className="important-icon"
+                    onClick={(e) => {
+                        e.stopPropagation(); // 이벤트 버블링 방지
+                        setShowIsLockedEditModal(true); // 잠금 상태 변경 모달만 열림
+                    }}
+                    style={{ left: '40px' }}
                 />
             </div>
+
             <h2>{title}</h2>
 
-            {/* 게시글 주인일 경우 항상 수정/삭제 아이콘 표시 */}
+            {/* 게시글 작성자만 수정/삭제 가능 */}
             {name === board.author && (
                 <div className="action-icons">
+                    {/* 수정 아이콘 */}
                     <img
                         src={`${imagePrefix}/shared/edit_document.png`}
                         alt="Edit"
                         className="edit-icon"
-                        onClick={() => setShowEditModal(true)}
+                        onClick={(e) => {
+                            e.stopPropagation(); // 이벤트 버블링 방지
+                            setShowEditModal(true); // 게시글 수정 모달만 열림
+                        }}
                     />
+                    {/* 삭제 아이콘 */}
                     <img
                         src={`${imagePrefix}/shared/delete.png`}
                         alt="Delete"
                         className="delete-icon"
-                        onClick={() => setShowDeleteModal(true)}
+                        onClick={(e) => {
+                            e.stopPropagation(); // 이벤트 버블링 방지
+                            setShowDeleteModal(true);
+                        }}
                     />
                 </div>
             )}

--- a/src/features/boards/department/components/boardDetails/EditIsImportantModal.js
+++ b/src/features/boards/department/components/boardDetails/EditIsImportantModal.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Modal, Button } from 'react-bootstrap';
+
+const EditIsImportantModal = ({ show, handleClose, handleEditIsImportantSubmit }) => {
+    return (
+        <Modal show={show} onHide={handleClose}>
+            <Modal.Header closeButton>
+                <Modal.Title>중요 표시 상태 변경</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                게시글의 중요 표시 상태를 변경하시겠습니까?
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant="primary" onClick={handleEditIsImportantSubmit}>
+                    확인
+                </Button>
+                <Button variant="secondary" onClick={handleClose}>
+                    취소
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+};
+
+export default EditIsImportantModal;

--- a/src/features/boards/department/components/boardDetails/EditIsLockedModal.js
+++ b/src/features/boards/department/components/boardDetails/EditIsLockedModal.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Modal, Button } from 'react-bootstrap';
+
+const EditIsLockedModal = ({ show, handleClose, handleEditIsLockedSubmit }) => {
+    return (
+        <Modal show={show} onHide={handleClose}>
+            <Modal.Header closeButton>
+                <Modal.Title>잠금 상태 변경</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                게시글의 잠금 상태를 변경하시겠습니까?
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant="primary" onClick={handleEditIsLockedSubmit}>
+                    확인
+                </Button>
+                <Button variant="secondary" onClick={handleClose}>
+                    취소
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+};
+
+export default EditIsLockedModal;

--- a/src/features/boards/department/components/boardDetails/EditModal.js
+++ b/src/features/boards/department/components/boardDetails/EditModal.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, Button, Form } from 'react-bootstrap';
+import {Button, Form, Modal} from 'react-bootstrap';
 
 const EditModal = ({ show, handleClose, editForm, setEditForm, handleEditSubmit, handleFileChange }) => {
     return (
@@ -57,14 +57,23 @@ const EditModal = ({ show, handleClose, editForm, setEditForm, handleEditSubmit,
                             onChange={(e) => setEditForm({ ...editForm, isImportant: e.target.checked })}
                         />
                     </Form.Group>
+                    <Form.Group className="mb-3">
+                        <Form.Check
+                            type="checkbox"
+                            label="잠금 여부"
+                            checked={editForm.isLocked}
+                            onChange={(e) => setEditForm({ ...editForm, isLocked: e.target.checked })}
+                        />
+                    </Form.Group>
                 </Form>
             </Modal.Body>
             <Modal.Footer>
-                <Button variant="secondary" onClick={handleClose}>
-                    취소
-                </Button>
                 <Button variant="primary" onClick={handleEditSubmit}>
                     저장
+                </Button>
+
+                <Button variant="secondary" onClick={handleClose}>
+                    취소
                 </Button>
             </Modal.Footer>
         </Modal>


### PR DESCRIPTION
부서 게시판 틀 구현 및 댓글 board 공용 폴더로 이동

** 실시간 적용이 안되는 이유
  server의  responseDto에 해당 필드의 값을 가져오지 않음 
  -> 이를 낙관적 UI를 통해 해결 vs ResponseDto에 필드를 추가해서 해결
  1. 낙관적 UI
      ** 서버에서 응답하는 DTO 필드가 없더라도 해당 API에 데이터를 담아서 서버로  갔을거라는 낙관적 전망으로 필드를 변경
      ** 서버에는 필드를 돌려줄 필요가 없기에 데이터의 전달 속도가 증가 -> 서버에 응답이 느리게 오더라도 클라이언트는 이를 실시간으로 전달 받아서 사용이 가능
      ** 추가적으로 낙관적 UI를 코드로 구현해야하는 복잡성 증가
      ** 데이터의 일관성 문제 : 일시적으로 클라이언트의 데이터와 서버의 데이터가 다르게 됨, 만약 예상과 다르게 데이터가 전달된다면 UI가 잘못된 데이터를 보내줄 수 있음.

  2. ResponseDto 
      ** 데이터의 일관성 : 서버에서 데이터를 보내는 것이기에 틀릴 이유가 없음
      ** 응답 속도 증가 : 그만큼 데이터를 서버에서 데이터를 받아서 와야하기에 돌려주는 데이터가 낙관적 UI에 비해 많아지기에 응답 속도가 증가함

  ** 결론
     낙관적 UI : '좋아요' 반응과 같은 경우는 많은 엔티티에 엮여있음 ex) reply의 reaction : board -> comment -> reply -> reaction의 순서로 해당 리액션을 찾아야하기에 많은 게시글의 댓글리스트 중 응답 리스트의 반응을 찾는건 서버의 응답 속도가 느릴 수 밖에 없기에 이는 빠르게 '좋아요'를 돌려주기 위해 낙관적 UI 사용
     ResponseDto : '좋아요' 반응을 제외한 모든 엔티티는 필드의 정확성이 상대적으로 중요함. 중요 게시글의 내용을 낙관적 UI로 사용한다고 가정하면 수정 API가 적용될 때, 게시글의 내용이 이상하게 변해서 가지고 오게 되면 안되기에 ResponseDto에 해당 field를 추가해서 가져오는 것으로 함.